### PR TITLE
Fix LibreOffice not being used for .rtf, .mht, .wps & .wri

### DIFF
--- a/OfficeConverter/Converter.cs
+++ b/OfficeConverter/Converter.cs
@@ -302,7 +302,10 @@ namespace OfficeConverter
                 case ".MHT":
                 case ".WPS":
                 case ".WRI":
-                    Word.Convert(inputFile, outputFile);
+                    if (UseLibreOffice)
+                        LibreOffice.Convert(inputFile, outputFile);
+                    else
+                        Word.Convert(inputFile, outputFile);
                     break;
 
                 case ".XLS":


### PR DESCRIPTION
Seems like converter wasn't checking if LibreOffice was being used for certain file types but LibreOffice supports those types of files.